### PR TITLE
Confirmation improvement

### DIFF
--- a/dist/css/smoke.css
+++ b/dist/css/smoke.css
@@ -110,7 +110,16 @@
     -webkit-box-shadow: 0 5px 25px -1px #333; /* Chrome & Safari */
     -moz-box-shadow: 0 5px 25px -1px #333; /* Firefox */
 }
-
+.smk-confirm:focus {
+    outline: 0;
+    box-shadow: 0 5px 25px -1px #333;
+    -webkit-box-shadow: 0 5px 25px -1px #333; /* Chrome & Safari */
+    -moz-box-shadow: 0 5px 25px -1px #333; /* Firefox */
+}
+.smk-confirm .panel-body {
+    padding-bottom: 30px;
+    padding-top: 30px;
+}
 
 
 

--- a/dist/js/smoke.js
+++ b/dist/js/smoke.js
@@ -667,12 +667,21 @@ $.smkConfirm = function(options, callback) {
         cancel: 'Cancelar'
     }, options);
     // Se agrega el panel de confirmacion en el body
-    $('body').append('<div class="smk-confirm-back"><div class="panel panel-default smk-confirm"><div class="panel-body"><br>' + settings.text + '<br><br></div><div class="panel-footer text-right"><a class="btn btn-default btn-sm smk-cancel" href="#" >' + settings.cancel + '</a> <a class="btn btn-primary btn-sm smk-accept" href="#">' + settings.accept + '</a></div></div></div>');
+    $('body').append('<div class="smk-confirm-back"><div class="panel panel-default smk-confirm" tabindex="1"><div class="panel-body">' + settings.text + '</div><div class="panel-footer text-right"><a class="btn btn-default btn-sm smk-cancel" href="#" >' + settings.cancel + '</a> <a class="btn btn-primary btn-sm smk-accept" href="#">' + settings.accept + '</a></div></div></div>');
     // Se aplica la animacion de entrada del panel de confirmacion
     $('.smk-confirm').animate({
         top: "-5px",
         opacity: '1'
-    }, 400);
+    }, 400, function(){ 
+        $('.smk-confirm').focus(); 
+    }).on('keydown', function(e) {
+        if (e.which === 27) {
+            $('.smk-cancel').click();
+        } else if (e.which === 13) {
+            if (!$('.smk-accept').is(":focus"))
+                $('.smk-accept').click();
+        }
+    });
     // Si se presiona el boton .smk-cancel se retorna false
     $('.smk-cancel').click(function(e) {
         e.preventDefault();


### PR DESCRIPTION
Enable support for keyboard events (Escape to cancel, Return to confirm). So, there is anymore the issue by pressing Enter calls another Confirmation (try this with Codepen example at http://alfredobarron.github.io/smoke/#/notifications simply pressing Enter after click on Confirmation button).

A cleaner template for better customization via CSS (removed "br" tags and managed space with padding).

A working example at http://codepen.io/anon/pen/XboRRe