### PR TITLE
Fullscreen improvement

### DIFF
--- a/dist/js/smoke.js
+++ b/dist/js/smoke.js
@@ -1104,15 +1104,16 @@ $.smkProgressBar = function(options) {
 $.fn.smkFullscreen = function() {
 
     // Se crea el boton fullscreen
-    var btnFullscreen = '<a class="btn smk-fullscreen" href="#" data-toggle="tooltip" data-placement="bottom" title="Fullscreen"><span class="glyphicon glyphicon-fullscreen" aria-hidden="true"></span></a>';
+    var btnFullscreen = '<span class="glyphicon glyphicon-fullscreen" aria-hidden="true"></span>';
 
     // Se agrega el boton fullscreen en el elemento
-    $(this).append(btnFullscreen);
+    $(this).addClass('smk-fullscreen').html(btnFullscreen);
 
     // Evento del boton fullscreen
-    $('.smk-fullscreen').click(function(event) {
+    $(this).click(function(event) {
         event.preventDefault();
         toggleFullScreen();
+        $('.smk-fullscreen > .glyphicon').toggleClass('glyphicon-fullscreen').toggleClass('glyphicon-resize-small');
     });
 
     // Se crea el metodo que dispara el fullscreen
@@ -1140,21 +1141,11 @@ $.fn.smkFullscreen = function() {
       }
     }
 
-    // Se crea el metodo que cambia el icono del boton
-    var changeFullscreen = function(){
-        $('.smk-fullscreen').children('.glyphicon').toggleClass('glyphicon-fullscreen').toggleClass('glyphicon-resize-small');
-    };
-
-    // Se escuchan los cambios del fullscreen
-    document.addEventListener("fullscreenchange", changeFullscreen, false);
-    document.addEventListener("msfullscreenchange", changeFullscreen, false);
-    document.addEventListener("mozfullscreenchange", changeFullscreen, false);
-    document.addEventListener("webkitfullscreenchange", changeFullscreen, false);
 };
 /*
 |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 |   Usage
-|   $('div').smkFullscreen();
+|   $('a#fullscreen').smkFullscreen();
 |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 */
 


### PR DESCRIPTION
A simple optimization (in my opinion): i removed anchor tag from fullscreen button definition and event listeners.

In this commit i want to:
1. avoid nested anchors (see example in http://alfredobarron.github.io/smoke/#/fullscreen);
2. have a cleaner code that works fine in all circumstances (have you tried to place it in a navbar?);
3. feel free to use my html code for button;
4. support also multiple button fullscreen in the same page;
5. optimize code removing event listener.

A working example at http://codepen.io/anon/pen/gpZRar