### PR TITLE
Panel improvement

### DIFF
--- a/dist/css/smoke.css
+++ b/dist/css/smoke.css
@@ -168,15 +168,19 @@
     top: 0;
     width: 100%;
     height: 100%;
+    border-radius: 0;
     z-index: 2050;
 }
-.smk-btn-group-panel-title{
-    top:-22px;
-    right: -4px
+.panel-full>.panel-heading{
+    border-radius: 0;
 }
-.smk-btn-group-panel{
-    top:-4px;
-    right: -4px
+a.smk-min,
+a.smk-min:focus,
+a.smk-remove,
+a.smk-remove:focus,
+a.smk-full,
+a.smk-full:focus {
+	color: inherit;
 }
 
 

--- a/dist/js/smoke.js
+++ b/dist/js/smoke.js
@@ -1177,16 +1177,19 @@ $.fn.smkPanel = function(options) {
     // Se quiebra la variable hideSinEspacios para obtener sus valores y se agregan en el array arrayHide
     var arrayHide = hideSinEspacios.split(',');
     // Se obtiene el .panel-title de cada panel
-    var panelHeading = $(this).children('.panel-heading').children('.panel-title');
-    var smkBtnGroupPanel = '';
-    if(panelHeading.length > 0){
-        smkBtnGroupPanel = 'smk-btn-group-panel-title';
-    }else{
-        smkBtnGroupPanel = 'smk-btn-group-panel';
+    var panelHeading = $(this).children('.panel-heading');
+    if (!panelHeading.length){
+    	panelHeading = $("<div>", {class: 'panel-heading'});
+    	$(this).prepend(panelHeading);
+    }
+    var panelTitle = panelHeading.children('.panel-title');
+    panelHeading.addClass('clearfix');
+    if(panelTitle.length){
+        panelTitle.addClass('pull-left');
     }
 
     // Se crea el btn-group
-    var btnGroup = '<div class="btn-group btn-group-sm pull-right ' + smkBtnGroupPanel + '" role="group">';
+    var btnGroup = '<div class="btn-group btn-group-xs pull-right" role="group">';
     // Se valida que no exista en el array el boton min para poder agregarlo dentro de btnGroup
     if($.inArray('min', arrayHide) == -1){
         btnGroup += '<a class="btn smk-min" href="#"><span class="glyphicon glyphicon-minus" aria-hidden="true"></span></a>';


### PR DESCRIPTION
1. cleaner code, pure bootstrap, that works in any case (also, for example, with panel without panel-title or without panel-heading);
2. replaced btn-group-sm with btn-group-xs to fix padding;
3. fix color of buttons (also for contextual alternatives, as panel-primary, panel-danger, …)
4. removed border-radius when panel is full

A working example at http://codepen.io/anon/pen/vOvZgN