### PR TITLE
Fix input radio and checkbox value

### DIFF
--- a/dist/js/smoke.js
+++ b/dist/js/smoke.js
@@ -117,7 +117,7 @@
       // Se obtiene el value de los input RADIO y/o CHECKBOX
       if (type === 'radio' || type === 'checkbox') {
         // Se obtiene el value del grupo de checks o radios
-        value = $("input[name=" + name + "]:checked").val();
+        value = $("input[name='" + name + "']:checked").val();
       }
 
       // Se validan los INPUTS que son requeridos y estan vacios


### PR DESCRIPTION
Fix #103
> Uncaught Error: Syntax error, unrecognized expression: input[name=project[type]]:checked

Line 120 must change from : 
`value = $("input[name=" + name + "]:checked").val();`
to
`value = $("input[name='" + name + "']:checked").val();`