### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#[Smoke](http://alfredobarron.github.io/smoke)
+# [Smoke](http://alfredobarron.github.io/smoke)
 
 ![Version](https://img.shields.io/github/release/alfredobarron/smoke.svg)
 ![Version](https://img.shields.io/bower/v/smoke.svg)
@@ -41,17 +41,17 @@ Read the [Getting started page](http://alfredobarron.github.io/smoke/#/getting-s
 
 
 
-##Required
+## Required
 
 Smoke plugin requires the [Jquery](http://jquery.com/) library and [Bootstrap 3.](http://getbootstrap.com/) framework.
 
 
 
-##Documentation
+## Documentation
 
 Documentation can check the [http://alfredobarron.github.io/smoke/](http://alfredobarron.github.io/smoke/)
 
-##How to contribute
+## How to contribute
 
 All contributions are very welcome, We love it. There are several ways to help out:
 
@@ -66,19 +66,19 @@ There are a few guidelines that we need contributors to follow so that we have a
 If you want to making changes Better avoid working directly on the master branch, to avoid conflicts if you pull in updates from origin, so, if make your contribution under the branch [`dev`](https://github.com/alfredobarron/smoke/tree/dev), into folder `docs/src/`.
 
 
-##Community
+## Community
 
 - Join [the official Slack room](https://smokejs.slack.com).
 - Implementation help may be found at Stack Overflow (tagged [`smoke`](http://stackoverflow.com/questions/tagged/smoke)).
 
 
-##Creators
+## Creators
 
 [@AlfredoBarronC](https://twitter.com/AlfredoBarronC)
 
 
 
-##Collaborators
+## Collaborators
 
 - [@misaelrojas](https://github.com/misaelrojas)
 - [@mostrosonido](https://twitter.com/mostrosonido)
@@ -93,6 +93,6 @@ If you want to making changes Better avoid working directly on the master branch
 
 
 
-##Copyright and license
+## Copyright and license
 
 Code and documentation (c) Copyright 2015 Alfredo Barron. Code published under [license LGPL](https://github.com/alfredobarron/smoke/blob/master/LICENSE)

--- a/docs/bower_components/angular-smoothscroll/README.md
+++ b/docs/bower_components/angular-smoothscroll/README.md
@@ -4,7 +4,7 @@ angular-smoothscroll
 AngularJS directives to get a smooth scroll effect (like this: http://css-tricks.com/examples/SmoothPageScroll/).
 Pure vanilla JS and jQuery versions.
 
-#How to use it?
+# How to use it?
 
 ## Demo 
 
@@ -25,28 +25,28 @@ Copy the last version from the `dist/scripts` folder
 
 Run `bower install angular-smoothscroll` in your project
 
-###Add the dependency to your app 
+### Add the dependency to your app 
 Declare an AngularJS module with a dependency: `app.module('myApp', ['angularSmoothscroll'])`
 
-##Vanilla JS (to improve, too fast) 
+## Vanilla JS (to improve, too fast) 
 
 Just declare an HTML link element which will start scroll, add the `smooth-scroll` directive and pass the target ID: `<a smooth-scroll target="target">Scroll to Target</a>`
 
-##jQuery version 
+## jQuery version 
 Declare an HTML link element which will start scroll, add the `smooth-scroll-jquery` directive and pass the target ID: `<a smooth-scroll-jquery target="target">Scroll to Target</a>`. No target means scroll to top.
 
 You can declare the speed (default is 500): `<a smooth-scroll-jquery target="target" speed="1000">Scroll to Target</a>`
 
 With both versions, you can declare the offset (default is 100): `<a smooth-scroll[-jquery] target="target" offset="30">Scroll to Target</a>`
 
-#How to contribute?
+# How to contribute?
 
 1. Clone this repo
 2. Make your changes
 3. Test them: `grunt test`
 4. Open a pull-request
 
-#To improve
+# To improve
 
 1. Vanilla JS implementation which is not working very well
 2. Make the Angular JS unit tests pass (cf. http://stackoverflow.com/questions/16929046/effectively-unit-test-an-angularjs-directive-which-is-manipulating-the-dom?noredirect=1#comment24448390_16929046)

--- a/docs/bower_components/angular-ui-router/CONTRIBUTING.md
+++ b/docs/bower_components/angular-ui-router/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Issues only! |
 -------------|
 Please keep in mind that the issue tracker is for *issues*. Please do *not* post an issue if you need help or support. Instead, see one of the above-mentioned forums or [IRC](irc://irc.freenode.net/#angularjs). |
 
-####Purple Labels
+#### Purple Labels
 A purple label means that **you** need to take some further action.  
  - ![Not Actionable - Need Info](http://angular-ui.github.io/ui-router/images/notactionable.png): Your issue is not specific enough, or there is no clear action that we can take. Please clarify and refine your issue.
  - ![Plunkr Please](http://angular-ui.github.io/ui-router/images/plunkrplease.png): Please [create a plunkr](http://bit.ly/UIR-Plunk)

--- a/docs/v2.2.4/bower_components/angular-smoothscroll/README.md
+++ b/docs/v2.2.4/bower_components/angular-smoothscroll/README.md
@@ -4,7 +4,7 @@ angular-smoothscroll
 AngularJS directives to get a smooth scroll effect (like this: http://css-tricks.com/examples/SmoothPageScroll/).
 Pure vanilla JS and jQuery versions.
 
-#How to use it?
+# How to use it?
 
 ## Demo 
 
@@ -25,28 +25,28 @@ Copy the last version from the `dist/scripts` folder
 
 Run `bower install angular-smoothscroll` in your project
 
-###Add the dependency to your app 
+### Add the dependency to your app 
 Declare an AngularJS module with a dependency: `app.module('myApp', ['angularSmoothscroll'])`
 
-##Vanilla JS (to improve, too fast) 
+## Vanilla JS (to improve, too fast) 
 
 Just declare an HTML link element which will start scroll, add the `smooth-scroll` directive and pass the target ID: `<a smooth-scroll target="target">Scroll to Target</a>`
 
-##jQuery version 
+## jQuery version 
 Declare an HTML link element which will start scroll, add the `smooth-scroll-jquery` directive and pass the target ID: `<a smooth-scroll-jquery target="target">Scroll to Target</a>`. No target means scroll to top.
 
 You can declare the speed (default is 500): `<a smooth-scroll-jquery target="target" speed="1000">Scroll to Target</a>`
 
 With both versions, you can declare the offset (default is 100): `<a smooth-scroll[-jquery] target="target" offset="30">Scroll to Target</a>`
 
-#How to contribute?
+# How to contribute?
 
 1. Clone this repo
 2. Make your changes
 3. Test them: `grunt test`
 4. Open a pull-request
 
-#To improve
+# To improve
 
 1. Vanilla JS implementation which is not working very well
 2. Make the Angular JS unit tests pass (cf. http://stackoverflow.com/questions/16929046/effectively-unit-test-an-angularjs-directive-which-is-manipulating-the-dom?noredirect=1#comment24448390_16929046)

--- a/docs/v2.2.4/bower_components/angular-ui-router/CONTRIBUTING.md
+++ b/docs/v2.2.4/bower_components/angular-ui-router/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Issues only! |
 -------------|
 Please keep in mind that the issue tracker is for *issues*. Please do *not* post an issue if you need help or support. Instead, see one of the above-mentioned forums or [IRC](irc://irc.freenode.net/#angularjs). |
 
-####Purple Labels
+#### Purple Labels
 A purple label means that **you** need to take some further action.  
  - ![Not Actionable - Need Info](http://angular-ui.github.io/ui-router/images/notactionable.png): Your issue is not specific enough, or there is no clear action that we can take. Please clarify and refine your issue.
  - ![Plunkr Please](http://angular-ui.github.io/ui-router/images/plunkrplease.png): Please [create a plunkr](http://bit.ly/UIR-Plunk)

--- a/docs/v2.2.4/bower_components/ngScrollSpy/README.md
+++ b/docs/v2.2.4/bower_components/ngScrollSpy/README.md
@@ -1,18 +1,18 @@
-#ngScrollSpy
+# ngScrollSpy
 
-###What is it?
+### What is it?
 A continuation of a previous project of mine, [ngPagemenu](https://github.com/mg/ngPagemenu), that adds features such as more defined api to work with the scroll event and an affix directive.
 
-###What functionality does it provide?
+### What functionality does it provide?
 
 + *ScrollSpy*: a service that provides an saner api to work with the scroll event.
 + *affix*: a directive to affix an DOM element to a boundary of the browser window.
 + *pagemenu* and pageitems: two directives to build a menu from the contents in the page.
 
-###The ScrollSpy service
+### The ScrollSpy service
 The *ScrollSpy* service provides an api to work with the scroll event. It builds up the two following objects that represent the event:
 
-####The Scroll Data Object
+#### The Scroll Data Object
     {
         width,              // width of browser window
         height,             // height of browser window
@@ -27,7 +27,7 @@ The *ScrollSpy* service provides an api to work with the scroll event. It builds
         overscrollBottom    // did we overscroll to the bottom?
     }
 
-####The Scroll Delta Object
+#### The Scroll Delta Object
     {
         width,      // the difference in width from last scroll event
         height,     // the difference in height from last scroll event
@@ -40,7 +40,7 @@ The *ScrollSpy* service provides an api to work with the scroll event. It builds
     }
 The data is normalized, e.g. any overscroll data is removed and instead flags are added to the data. The velocity is calculated as poistion delta divided by window size, e.g. (curY - prevY) / height.
 
-#####Registering a scroll handler
+##### Registering a scroll handler
 
     ScrollSpy.addHandler(cond,handler) { return handler-id }:
     cond: function(ScrollData, ScrollDelta) { return true/false }
@@ -48,19 +48,19 @@ The data is normalized, e.g. any overscroll data is removed and instead flags ar
 
 A generic function to add a scroll handler. The *cond* function return true or false based on the data in the two parameters it receives. If the *cond* function returns true the handler get's called with the two objects. The addHandler function returns an id to the handler. Use the id to clean up once the handler is no longer needed. **In most cases you should not use this hook unless you need very special condition logic**.
 
-#####Cleanup on destory event
+##### Cleanup on destory event
 
     ScrollSpy.removeHandler(id):
 
 Remove handler. Use this to clean up once you don't need to receive the event any more.
 
-#####Trigger the scroll event
+##### Trigger the scroll event
 
     ScrollSpy.trigger(): 
 
 Use this function to programatically trigger a scroll event. Sets the property *isForced* to true while the event handlers are executed.
 
-#####Recieve all scroll events
+##### Recieve all scroll events
 
     ScrollSpy.onScroll(handler) { return handler-id }:
     
@@ -68,7 +68,7 @@ Use this function to programatically trigger a scroll event. Sets the property *
 
 Register a handler that receives all scroll events.
 
-#####Handling scrolling along single axis
+##### Handling scrolling along single axis
 
     ScrollSpy.onYScroll(handler) { return handler-id }:
     ScrollSpy.onXScroll(handler) { return handler-id }:
@@ -77,7 +77,7 @@ Register a handler that receives all scroll events.
 
 Register a handler to receive a scroll event along the Y axis or the X axis.
 
-#####Handling vertical overscroll
+##### Handling vertical overscroll
 
     ScrollSpy.onOverscrollVert(handler) { return handler-id }:
     ScrollSpy.onOverscrollTop(hatndler) { return handler-id }:
@@ -87,7 +87,7 @@ Register a handler to receive a scroll event along the Y axis or the X axis.
 
 Recieve overscroll events along the Y axis.
 
-#####Handling horizontal overscroll
+##### Handling horizontal overscroll
 
     ScrollSpy.onOverscrollHorz(handler) { return handler-id }:
     ScrollSpy.onOverscrollLeft(handler) { return handler-id }:
@@ -136,7 +136,7 @@ This will be mapped to the following tree:
     Item 6
         Item 7
 
-###How do I use it?
+### How do I use it?
 Install with bower:
 
     bower install ngScrollSpy --save
@@ -149,26 +149,26 @@ And add ngScrollSpy as a dependency for your app:
 
     angular.module('myApp', ['ngScrollSpy']);
 
-###Dependencies?
+### Dependencies?
 Only AngularJS.
 
-###Example?
+### Example?
 The *demo* directory contains three demo files:
 
 + *horz.html*: A demonstration of affixing a DOM element to either the left or the right edge of the window.
 + *vert.html*: A demonstration of affixing a DOM element to either the top or the bottom edge of the window.
 + *pagemenu.html*: A demonstration of a page menu.
 
-###Credits?
+### Credits?
 Aside for the Bootstrap people for the obvious inspiration, the pagemenu code was inspired by Evil Closet Monkey's answer to a question on [StackExchange](http://stackoverflow.com/questions/17470370/how-to-implement-a-scrollspy-in-angular-js-the-right-way).
 
-###And you are?
+### And you are?
 Magnús Örn Gylfason, a web programmer working in the banking industry in Iceland. You can contact me at
 
 + Twitter: [@mgns74](https://www.twitter.com/mgns74)
 + Google+: [Magnús Örn Gylfason](https://plus.google.com/u/0/+MagnúsÖrnGylfason/posts)
 
-###Licence
+### Licence
 The MIT License (MIT)
 
 Copyright (c) 2014 Magnús Örn Gylfason


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
