### PR TITLE
Update smoke.js

### DIFF
--- a/dist/js/smoke.js
+++ b/dist/js/smoke.js
@@ -181,10 +181,13 @@
 
             // Se valida el input NUMBER RANGE
             if ((typeof(smkMin) !== 'undefined' || typeof(smkMax) !== 'undefined')) {
-              if((value < smkMin) || (value > smkMax)){
+              var valueNumber = parsetInt(value);
+              var smkMinNumber = parseInt(smkMin);
+              var smkMaxNumber = parseInt(smkMax);
+              if((valueNumber < smkMinNumber) || (valueNumber > smkMaxNumber)){
                 var arrayTextNumberRange = [];
-                arrayTextNumberRange[0] = parseInt(smkMin-1);
-                arrayTextNumberRange[1] = parseInt(smkMax)+1;
+                arrayTextNumberRange[0] = smkMinNumber-1;
+                arrayTextNumberRange[1] = smkMaxNumber+1;
                 var textNumberRange = $.smokeCustomizeMsg(languaje.textNumberRange, arrayTextNumberRange);
                 // Se agrega el mensaje de error
                 result = $.smkAddError(input, textNumberRange);


### PR DESCRIPTION
En caso de un number range, se hacia la comparación con string, que en algunos casos provoca errores de validación, ya que una comparación por string compara número a número y si alguno es true la comparación devuelve true. Esto provoca que en el caso de que no haya el mismo número de dígitos el resultado es erróneo. Por ejemplo "12">"100", se compara:
* 1 > 1 (false)
* 2 > 0 (true)

Para de comparar y devuelve true, por lo que 12 > 100 devuelve true y la validación devuelve error de que el número está fuera de rango.